### PR TITLE
Renamed the Json to GraphSON.

### DIFF
--- a/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -19,8 +19,8 @@ scriptEngines: {
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.JsonMessageSerializerGremlinV1d0 }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.JsonMessageSerializerV1d0 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {


### PR DESCRIPTION
In the titan09 snapshot: 
The Json serializers have been renamed in M9, changed the config file to reflect this. (gremlin server will throw warnings saying it can't find the serializers if not).

With that said. GraphSON seems to be default now, it may be possible to simply remove these two lines.
